### PR TITLE
Fixes empty API responses when used  with phergie/phergie-irc-plugin-…

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use Phergie\Irc\Bot\React\EventQueueInterface as Queue;
 use Phergie\Irc\Plugin\React\Command\CommandEvent as Event;
 use Phergie\Plugin\Http\Request as HttpRequest;
 use Chrismou\Phergie\Plugin\Google\Provider\GoogleProviderInterface;
+use GuzzleHttp\Message\Response;
 
 /**
  * Plugin class.
@@ -131,8 +132,8 @@ class Plugin extends AbstractPlugin
 
         return new HttpRequest(array(
             'url' => $provider->getApiRequestUrl($event),
-            'resolveCallback' => function ($data) use ($self, $event, $queue, $provider) {
-                $self->sendIrcResponse($event, $queue, $provider->getSuccessLines($event, $data));
+            'resolveCallback' => function (Response $response) use ($self, $event, $queue, $provider) {
+                $self->sendIrcResponse($event, $queue, $provider->getSuccessLines($event, $response));
             },
             'rejectCallback' => function ($error) use ($self, $event, $queue, $provider) {
                 $self->sendIrcResponse($event, $queue, $provider->getRejectLines($event, $error));

--- a/src/Provider/GoogleSearch.php
+++ b/src/Provider/GoogleSearch.php
@@ -65,7 +65,7 @@ class GoogleSearch implements GoogleProviderInterface
      */
     public function getSuccessLines(Event $event, $apiResponse)
     {
-        $json = json_decode($apiResponse);
+        $json = json_decode($apiResponse->getBody());
         $json = $json->responseData;
 
         if (isset($json->cursor->estimatedResultCount) && $json->cursor->estimatedResultCount > 0) {

--- a/src/Provider/GoogleSearchCount.php
+++ b/src/Provider/GoogleSearchCount.php
@@ -30,7 +30,7 @@ class GoogleSearchCount extends GoogleSearch implements GoogleProviderInterface
      */
     public function getSuccessLines(Event $event, $apiResponse)
     {
-        $json = json_decode($apiResponse);
+        $json = json_decode($apiResponse->getBody());
         $json = $json->responseData;
 
         $messages = array();


### PR DESCRIPTION
Fixes empty API responses when used  with phergie/phergie-irc-plugin-react-url version 2+

Not sure how to get around the test failure since you're actually using mocked up JSON results.

Tests will currently fail because your tests are using string JSON instead of actual mocked Guzzle responses.

```
PHPUnit 4.8.18 by Sebastian Bergmann and contributors.

Runtime:        PHP 5.6.16
Configuration:  /Users/halo/PhpstormProjects/phergie-irc-plugin-react-google/phpunit.xml

....PHP Fatal error:  Call to a member function getBody() on string in /phergie-irc-plugin-react-google/src/Provider/GoogleSearch.php on line 68

Fatal error: Call to a member function getBody() on string in /phergie-irc-plugin-react-google/src/Provider/GoogleSearch.php on line 68
```
